### PR TITLE
Added back keywords for listing on Sketch’s site

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,9 @@
     "color-contrast",
     "color-contrast-checker",
     "accessibility-checker",
-    "a11y"
+    "a11y",
+    "sketch assistant",
+    "public"
   ],
   "files": [
     "dist"


### PR DESCRIPTION
As documented on https://developer.sketch.com/assistants/publishing#listing-on-sketchcom